### PR TITLE
Implement the ability to run a mutable trait method & various chore-related changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["autoref", "autoderef", "specialization", "specialisation"]
 categories = ["rust-patterns", "development-tools", "development-tools::procedural-macro-helpers", "no-std"]
 
 [lib]
-proc_macro = true
+proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ proc_macro = true
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
 syn = { version = "2.0.15", features = ["full"] }
+
+[dev-dependencies]
+syn = { version = "2.0.15", features = ["extra-traits"] }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,6 +3,7 @@ use std::iter::FromIterator;
 use syn::punctuated::Punctuated;
 use syn::Token;
 
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct Args {
 	pub for_token: Token![for],
 	pub param: Option<syn::Ident>,
@@ -12,6 +13,7 @@ pub struct Args {
 	pub arms: Vec<Arm>,
 }
 
+#[cfg_attr(debug_assertions, derive(Debug))]
 pub struct Arm {
 	pub match_token: Token![match],
 	pub generics: syn::Generics,


### PR DESCRIPTION
I found `spez` on my search trying to find a way to run specialized code on an object. I quickly found out that while:

```rust
spez! {
	for x = &my_object;
		match<T> T where T: MyTrait {
			x.do_something_immutable();
		}
	match<T> T {}
};
```

was perfectly valid, the following wasn't:

```rust
spez! {
	for x = &mut my_object;
		match<T> T where T: MyTrait {
			x.do_something_mutable();
		}
	match<T> T {}
};
```

Turns out that the macro didn't care whether the reference was mutable or not and borrowed the object with an immutable reference, even if the reference itself is mutable! This has now been fixed.

I know that this crate hasn't been update in 2 years, but I would appreciate it if you were to make a release to `crates.io`. Something that I am building depends on that very behavior and I don't want to fork this and publish it as `spez-mut` just for that one feature.

Thanks in advance